### PR TITLE
acquire IP address only when strictly necessary

### DIFF
--- a/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/net/DeviceScanner.kt
+++ b/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/net/DeviceScanner.kt
@@ -9,7 +9,7 @@ class DeviceScanner(username: String, password: String) {
 
     private val username: String
     private val password: String
-    private var addressToSearch: List<String>? = null
+    private var addressToSearch: List<String> = listOf()
 
     val devices: MutableList<Device>
 
@@ -27,15 +27,18 @@ class DeviceScanner(username: String, password: String) {
     }
 
     fun scanNetwork(deviceIp: String, deviceMask: String) {
-        // get address to fetch
-        val addressToFetch = if (this.addressToSearch != null) {
-            this.addressToSearch!!.map {
+        doScanNetwork(buildNetworkAddressList(deviceIp, deviceMask))
+    }
+
+    fun scanNetwork() {
+        doScanNetwork(
+            this.addressToSearch.map {
                 Inet4Address.getByName(it) as Inet4Address
             }
-        } else {
-            buildNetworkAddressList(deviceIp, deviceMask)
-        }
+        )
+    }
 
+    private fun doScanNetwork(addressToFetch: List<Inet4Address>) {
         val scanners = addressToFetch.map {
             DeviceScannerWorker(it, username, password)
         }


### PR DESCRIPTION
# ISSUE 6 - Require WiFi only to retrieve Ip Address

Fixes #6 

## Description

- Use WiFi only when strictly necessary (when there's no cached device list and no link defined)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Acceptance tests

- [x] regression test: device scanner works when provided with the device list
- [x] regression test: device scanner works when provided with IP address and netmask

