### PR TITLE
Scan devices ONLY when there's no cached device

### DIFF
--- a/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/MainActivity.kt
+++ b/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/MainActivity.kt
@@ -73,13 +73,7 @@ class MainActivity : Activity() {
             Log.d(TAG, "Credentials are null; handling null credentials")
             onNullCredentials()
         } else {
-            if (devices.isEmpty()) {
-                Log.d(TAG, "Device list is empty; discover devices")
-                discoverDevices()
-            }
-            // reload device state
-            Log.d(TAG, "Credentials are set; reloading device state...")
-            reloadDeviceState()
+            onCredentials()
         }
 
         // Button listeners
@@ -196,19 +190,30 @@ class MainActivity : Activity() {
 
         // if still NULL; try to read from intent
         if (this.credentials != null) {
-            try {
-                discoverDevices()
-            } catch (e: Exception) {
-                e.printStackTrace()
-                Log.e(TAG, String.format("Failed to discover devices: %s", e))
-                setActivityState(ActivityState.NO_DEVICE_FOUND)
-            }
+            onCredentials()
         } else {
             Log.d(
                 TAG,
                 "Credentials not in intent and not in preferences. Starting LoginActivity"
             )
             startActivityForResult(Intent(this, LoginActivity::class.java), 1)
+        }
+    }
+
+    private fun onCredentials() {
+        try {
+            if (devices.isEmpty()) {
+                Log.d(TAG, "Device list is empty; discover devices")
+                discoverDevices()
+            } else {
+                // reload device state
+                Log.d(TAG, "Credentials are set; reloading device state...")
+                reloadDeviceState()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Log.e(TAG, String.format("Failed to discover devices: %s", e))
+            setActivityState(ActivityState.NO_DEVICE_FOUND)
         }
     }
 
@@ -254,7 +259,7 @@ class MainActivity : Activity() {
         val client = TpLinkCloudClient()
         client.login(username, password)
         this.credentials = Credentials(username, password)
-        discoverDevices()
+        onCredentials()
     }
 
     private fun discoverDevices() {

--- a/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/net/DeviceScanner.kt
+++ b/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/net/DeviceScanner.kt
@@ -9,7 +9,6 @@ class DeviceScanner(username: String, password: String) {
 
     private val username: String
     private val password: String
-    private var addressToSearch: List<String> = listOf()
 
     val devices: MutableList<Device>
 
@@ -19,23 +18,8 @@ class DeviceScanner(username: String, password: String) {
         this.devices = mutableListOf()
     }
 
-    constructor(username: String, password: String, addressToSearch: List<String>) : this(
-        username,
-        password
-    ) {
-        this.addressToSearch = addressToSearch.sorted()
-    }
-
     fun scanNetwork(deviceIp: String, deviceMask: String) {
         doScanNetwork(buildNetworkAddressList(deviceIp, deviceMask))
-    }
-
-    fun scanNetwork() {
-        doScanNetwork(
-            this.addressToSearch.map {
-                Inet4Address.getByName(it) as Inet4Address
-            }
-        )
     }
 
     private fun doScanNetwork(addressToFetch: List<Inet4Address>) {

--- a/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/tapo/device/DeviceStatus.kt
+++ b/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/tapo/device/DeviceStatus.kt
@@ -3,6 +3,7 @@ package dev.veeso.opentapowearos.tapo.device
 import android.os.Parcel
 import android.os.Parcelable
 
+@kotlinx.serialization.Serializable
 data class DeviceStatus(
     val deviceOn: Boolean,
     val brightness: Int? = null,

--- a/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/view/app_data/DeviceCache.kt
+++ b/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/view/app_data/DeviceCache.kt
@@ -1,27 +1,63 @@
 package dev.veeso.opentapowearos.view.app_data
 
+import dev.veeso.opentapowearos.tapo.device.Device
+import dev.veeso.opentapowearos.tapo.device.DeviceBuilder
+import dev.veeso.opentapowearos.tapo.device.DeviceModel
+import dev.veeso.opentapowearos.tapo.device.DeviceStatus
+import dev.veeso.opentapowearos.view.intent_data.DeviceData
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 
-class DeviceCache(devices: List<String>) {
+class DeviceCache(devices: List<Device>) {
 
-    private var devices: MutableList<String>
+    private var devices: List<Device>
 
     init {
         this.devices = devices.toMutableList()
     }
 
     constructor(payload: String) : this(listOf()) {
-        this.devices = Json.decodeFromString(payload)
+        val deviceData: List<CachedDevice> = Json.decodeFromString(payload)
+        this.devices = deviceData.map {
+            DeviceBuilder.buildDevice(
+                it.alias,
+                it.id,
+                it.model,
+                it.endpoint,
+                it.ipAddress,
+                it.status
+            )
+        }
+
     }
 
     fun serialize(): String {
-        return Json.encodeToString(devices)
+        val serialized: List<CachedDevice> = this.devices.map {
+            CachedDevice(
+                it.alias,
+                it.id,
+                it.model,
+                it.endpoint,
+                it.ipAddress,
+                it.status
+            )
+        }
+        return Json.encodeToString(serialized)
     }
 
-    fun devices(): List<String> {
-        return this.devices.toList()
+    fun devices(): List<Device> {
+        return this.devices
     }
 
 }
+
+@kotlinx.serialization.Serializable
+data class CachedDevice(
+    val alias: String,
+    val id: String,
+    val model: DeviceModel,
+    val endpoint: String,
+    val ipAddress: String,
+    val status: DeviceStatus
+)

--- a/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/view/main_activity/DeviceListAdapter.kt
+++ b/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/view/main_activity/DeviceListAdapter.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import dev.veeso.opentapowearos.DeviceActivity
 import dev.veeso.opentapowearos.R
 import dev.veeso.opentapowearos.tapo.device.Device
+import dev.veeso.opentapowearos.view.intent_data.Credentials
 import kotlinx.coroutines.*
 
 @OptIn(DelicateCoroutinesApi::class)
@@ -20,6 +21,7 @@ internal class DeviceListAdapter(private val devices: List<Device>) :
     var onItemClick: ((Device) -> Unit)? = null
     var onItemLongClick: ((Device) -> Unit)? = null
     var selected: Boolean = false
+    lateinit var credentials: Credentials
 
     internal inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val deviceAliasText: TextView = view.findViewById(R.id.device_list_item_alias)
@@ -78,6 +80,10 @@ internal class DeviceListAdapter(private val devices: List<Device>) :
         GlobalScope.launch {
             withContext(Dispatchers.IO) {
                 try {
+                    if (!device.authenticated) {
+                        Log.d(TAG, String.format("Device %s is not authenticated yet; signing in", device.alias))
+                        device.login(credentials.username, credentials.password)
+                    }
                     if (powerState) {
                         device.on()
                     } else {

--- a/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/view/main_activity/GroupListAdapter.kt
+++ b/OpenTapoWearOs/app/src/main/java/dev/veeso/opentapowearos/view/main_activity/GroupListAdapter.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import dev.veeso.opentapowearos.DeviceActivity
 import dev.veeso.opentapowearos.R
 import dev.veeso.opentapowearos.tapo.device.Device
+import dev.veeso.opentapowearos.view.intent_data.Credentials
 import kotlinx.coroutines.*
 
 @OptIn(DelicateCoroutinesApi::class)
@@ -20,6 +21,7 @@ internal class GroupListAdapter(private val groups: List<Pair<String, List<Devic
     var onItemClick: ((String) -> Unit)? = null
     var onItemLongClick: ((String) -> Unit)? = null
     var selected: Boolean = false
+    lateinit var credentials: Credentials
 
     internal inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val groupNameText: TextView = view.findViewById(R.id.group_list_item_name)
@@ -91,6 +93,16 @@ internal class GroupListAdapter(private val groups: List<Pair<String, List<Devic
                         )
                     )
                     try {
+                        if (!it.authenticated) {
+                            Log.d(
+                                DeviceListAdapter.TAG,
+                                String.format(
+                                    "Device %s is not authenticated yet; signing in",
+                                    it.alias
+                                )
+                            )
+                            it.login(credentials.username, credentials.password)
+                        }
                         if (powerState) {
                             it.on()
                         } else {


### PR DESCRIPTION
# ISSUE 7 - Scan devices ONLY when there's no cached device

Fixes #7 

## Description

- cached IP address list to cached devices with all attributes
- don't scan devices if cache is set
- on main activity, sign in if not authenticated in adapters

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the contribution guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

- [x] regression test: I can still power on/off devices and groups from Main Activity.
- [x] regression test: device scan still works

